### PR TITLE
Fixes #16 Ignored defaults

### DIFF
--- a/src/MetaTags/Concerns/InitializeDefaults.php
+++ b/src/MetaTags/Concerns/InitializeDefaults.php
@@ -13,24 +13,40 @@ trait InitializeDefaults
             $this->setTitle($title);
         }
 
+        if (!empty($title = $this->config('title.max_length'))) {
+            $this->getTitle()->setMaxLength($this->config('title.max_length'));
+        }
+
+        if (!empty($title = $this->config('title.separator'))) {
+            $this->setTitleSeparator($title);
+        }
+
         if (!empty($description = $this->config('description.default'))) {
             $this->setDescription($description);
+        }
+
+        if (!empty($title = $this->config('description.max_length'))) {
+            $this->getDescription()->setMaxLength($this->config('description.max_length'));
         }
 
         if (!empty($keywords = $this->config('keywords.default'))) {
             $this->setKeywords($keywords);
         }
 
+        if (!empty($title = $this->config('keywords.max_length'))) {
+            $this->getKeywords()->setMaxLength($this->config('keywords.max_length'));
+        }
+
         if (!empty($charset = $this->config('charset'))) {
             $this->setCharset($charset);
         }
 
-        if (!empty($viewport = $this->config('viewport'))) {
-            $this->setViewport($viewport);
-        }
-
         if (!empty($robots = $this->config('robots'))) {
             $this->setRobots($robots);
+        }
+
+        if (!empty($viewport = $this->config('viewport'))) {
+            $this->setViewport($viewport);
         }
 
         if ($showCSRFToken = $this->config('csrf_token')) {


### PR DESCRIPTION
- Add the missing options to `InitializeDefaults.php` to ensure all options from the default `meta_tags.php` config file are supported.