### PR TITLE
Added ability to use anonymous functions as tag attribute value

### DIFF
--- a/README.md
+++ b/README.md
@@ -898,6 +898,17 @@ $tag = new \Butschster\Head\MetaTags\Entities\Tag('link', [
 
 $tag->toHtml();
 // <link rel="favicon" href="http://site.com" />
+
+// Tag with anonymous function
+$tag = new \Butschster\Head\MetaTags\Entities\Tag('meta', [
+    'name' => 'csrf-token',
+    'content' => function () {
+        return Session::token();
+    }
+]);
+
+$tag->toHtml();
+// <meta name="csrf-token" content="8760b1d530d60d2cba6fe81cb12d67c0">
 ```
 
 **Set the placement**

--- a/src/MetaTags/Concerns/ManageMetaTags.php
+++ b/src/MetaTags/Concerns/ManageMetaTags.php
@@ -167,7 +167,9 @@ trait ManageMetaTags
     public function addCsrfToken()
     {
         return $this->addMeta('csrf-token', [
-            'content' => Session::token(),
+            'content' => function() {
+                return Session::token();
+            },
         ]);
     }
 

--- a/src/MetaTags/Entities/Tag.php
+++ b/src/MetaTags/Entities/Tag.php
@@ -4,6 +4,7 @@ namespace Butschster\Head\MetaTags\Entities;
 
 use Butschster\Head\MetaTags\Meta;
 use Butschster\Head\Contracts\MetaTags\Entities\TagInterface;
+use Closure;
 
 class Tag implements TagInterface
 {
@@ -119,6 +120,10 @@ class Tag implements TagInterface
         // form like required="required" instead of using incorrect numerics.
         if (is_numeric($key)) {
             return $value;
+        }
+
+        if ($value instanceof Closure) {
+            $value = $value();
         }
 
         if (!is_null($value)) {

--- a/tests/MetaTags/Entities/TagTest.php
+++ b/tests/MetaTags/Entities/TagTest.php
@@ -8,6 +8,19 @@ use Butschster\Tests\TestCase;
 
 class TagTest extends TestCase
 {
+    function test_attribute_value_can_be_callable()
+    {
+        $this->assertHtmlableEquals(
+            '<meta name="custom" content="test data">',
+            new Tag('meta', [
+                'name' => 'custom',
+                'content' => function () {
+                    return 'test data';
+                }
+            ])
+        );
+    }
+
     function test_it_can_be_rendered_to_string()
     {
         $this->assertHtmlableEquals(

--- a/tests/MetaTags/MetaTest.php
+++ b/tests/MetaTags/MetaTest.php
@@ -11,7 +11,7 @@ class MetaTest extends TestCase
 {
     function test_class_can_be_initialized_with_default_values()
     {
-        Session::shouldReceive('token')->once()->andReturn('token');
+        Session::shouldReceive('token')->andReturn('token');
         $manager = new Manager();
 
         $manager->create('jquery', function ($package) {


### PR DESCRIPTION
```php
new Tag('meta', [
    'name' => 'csrf-token',
    'content' => function () {
        return Session::token();
    }
])
```

fixed #19