### PR TITLE
Added ability to add visibility condition for tag entities.

### DIFF
--- a/README.md
+++ b/README.md
@@ -933,6 +933,14 @@ $tag = new \Butschster\Head\MetaTags\Entities\Tag(...);
 $tag->getPlacement() // Will return specified placement;
 ```
 
+**Set visibility condition**
+```php
+$tag = new \Butschster\Head\MetaTags\Entities\Tag(...);
+$tag->visibleWhen(function () {
+    return Request::ip() === '127.0.0.1';
+});
+```
+
 ### Title
 ---
 `\Butschster\Head\MetaTags\Entities\Title`

--- a/README.md
+++ b/README.md
@@ -886,7 +886,11 @@ $tag = new \Butschster\Head\MetaTags\Entities\Tag('meta', [
     'name' => 'author',
     'content' => 'butschster'
 ]);
-
+// or
+$tag = \Butschster\Head\MetaTags\Entities\Tag::meta([
+    'name' => 'author',
+    'content' => 'butschster'
+]);
 $tag->toHtml();
 // <meta name="author" content="butschster">
 
@@ -895,6 +899,11 @@ $tag = new \Butschster\Head\MetaTags\Entities\Tag('link', [
     'rel' => 'favicon',
     'href' => 'http://site.com'
 ], true);
+// or
+$tag = \Butschster\Head\MetaTags\Entities\Tag::link([
+    'rel' => 'favicon',
+    'href' => 'http://site.com'
+]);
 
 $tag->toHtml();
 // <link rel="favicon" href="http://site.com" />
@@ -909,6 +918,7 @@ $tag = new \Butschster\Head\MetaTags\Entities\Tag('meta', [
 
 $tag->toHtml();
 // <meta name="csrf-token" content="8760b1d530d60d2cba6fe81cb12d67c0">
+
 ```
 
 **Set the placement**

--- a/src/Contracts/MetaTags/Entities/HasVisibilityConditions.php
+++ b/src/Contracts/MetaTags/Entities/HasVisibilityConditions.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Butschster\Head\Contracts\MetaTags\Entities;
+
+use Closure;
+
+interface HasVisibilityConditions
+{
+
+    /**
+     * Check if entity should be rendered
+     *
+     * @return bool
+     */
+    public function isVisible(): bool;
+
+    /**
+     * Add visibility condition
+     * @param Closure $condition
+     *
+     * @return $this
+     */
+    public function visibleWhen(Closure $condition);
+}

--- a/src/Contracts/MetaTags/Entities/TagInterface.php
+++ b/src/Contracts/MetaTags/Entities/TagInterface.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Support\Htmlable;
 interface TagInterface extends Htmlable
 {
     /**
+     * Get tag placement (footer, head, ...)
      * @return string
      */
     public function getPlacement(): string;

--- a/src/MetaTags/Concerns/ManageAssets.php
+++ b/src/MetaTags/Concerns/ManageAssets.php
@@ -13,12 +13,10 @@ trait ManageAssets
      */
     public function addStyle(string $name, string $src, array $attributes = [])
     {
-        $this->addTag(
+        return $this->addTag(
             $name,
             new Style($name, $src, $attributes)
         );
-
-        return $this;
     }
 
     /**
@@ -26,11 +24,9 @@ trait ManageAssets
      */
     public function addScript(string $name, string $src, array $attributes = [], string $placement = Meta::PLACEMENT_FOOTER)
     {
-        $this->addTag(
+        return $this->addTag(
             $name,
             new Script($name, $src, $attributes, $placement)
         );
-
-        return $this;
     }
 }

--- a/src/MetaTags/Entities/Comment.php
+++ b/src/MetaTags/Entities/Comment.php
@@ -2,10 +2,14 @@
 
 namespace Butschster\Head\MetaTags\Entities;
 
+use Butschster\Head\Contracts\MetaTags\Entities\HasVisibilityConditions;
 use Butschster\Head\Contracts\MetaTags\Entities\TagInterface;
+use Butschster\Head\MetaTags\Entities\Concerns\ManageVisibility;
 
-class Comment implements TagInterface
+class Comment implements TagInterface, HasVisibilityConditions
 {
+    use ManageVisibility;
+
     /**
      * @var string
      */

--- a/src/MetaTags/Entities/Concerns/ManageVisibility.php
+++ b/src/MetaTags/Entities/Concerns/ManageVisibility.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Butschster\Head\MetaTags\Entities\Concerns;
+
+use Closure;
+
+trait ManageVisibility
+{
+    /**
+     * Visibility condition
+     * @var Closure
+     */
+    protected $visibilityCondition = null;
+
+    /**
+     * @inheritDoc
+     */
+    public function visibleWhen(Closure $condition)
+    {
+        $this->visibilityCondition = $condition;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isVisible(): bool
+    {
+        if ($this->visibilityCondition instanceof Closure) {
+            return call_user_func($this->visibilityCondition);
+        }
+
+        return true;
+    }
+}

--- a/src/MetaTags/Entities/JavascriptVariables.php
+++ b/src/MetaTags/Entities/JavascriptVariables.php
@@ -2,14 +2,16 @@
 
 namespace Butschster\Head\MetaTags\Entities;
 
+use Butschster\Head\Contracts\MetaTags\Entities\HasVisibilityConditions;
 use Butschster\Head\Contracts\MetaTags\Entities\TagInterface;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use InvalidArgumentException;
 
-class JavascriptVariables implements TagInterface
+class JavascriptVariables implements TagInterface, HasVisibilityConditions
 {
-    use Concerns\ManagePlacements;
+    use Concerns\ManagePlacements,
+        Concerns\ManageVisibility;
 
     /**
      * @var array

--- a/src/MetaTags/Entities/Tag.php
+++ b/src/MetaTags/Entities/Tag.php
@@ -2,13 +2,14 @@
 
 namespace Butschster\Head\MetaTags\Entities;
 
-use Butschster\Head\MetaTags\Meta;
+use Butschster\Head\Contracts\MetaTags\Entities\HasVisibilityConditions;
 use Butschster\Head\Contracts\MetaTags\Entities\TagInterface;
 use Closure;
 
-class Tag implements TagInterface
+class Tag implements TagInterface, HasVisibilityConditions
 {
-    use Concerns\ManagePlacements;
+    use Concerns\ManagePlacements,
+        Concerns\ManageVisibility;
 
     /**
      * Make a new instance

--- a/src/MetaTags/Entities/Title.php
+++ b/src/MetaTags/Entities/Title.php
@@ -2,13 +2,13 @@
 
 namespace Butschster\Head\MetaTags\Entities;
 
+use Butschster\Head\Contracts\MetaTags\Entities\HasVisibilityConditions;
 use Butschster\Head\Contracts\MetaTags\Entities\TitleInterface;
-use Illuminate\Support\Str;
-use InvalidArgumentException;
 
-class Title implements TitleInterface
+class Title implements TitleInterface, HasVisibilityConditions
 {
-    use Concerns\ManageMaxLength;
+    use Concerns\ManageMaxLength,
+        Concerns\ManageVisibility;
 
     const DEFAULT_LENGTH = null;
 

--- a/src/MetaTags/Entities/YandexMetrika.php
+++ b/src/MetaTags/Entities/YandexMetrika.php
@@ -41,7 +41,7 @@ class YandexMetrika implements TagInterface
      */
     public function __call($method, $arguments)
     {
-        if (! method_exists($this->builder, $method)) {
+        if (!method_exists($this->builder, $method)) {
             throw new BadMethodCallException(sprintf(
                 'Method %s::%s does not exist.', get_class($this->builder), $method
             ));
@@ -59,7 +59,7 @@ class YandexMetrika implements TagInterface
      */
     public function toHtml()
     {
-        return (string) $this->builder;
+        return (string)$this->builder;
     }
 
     /**

--- a/src/MetaTags/Placement.php
+++ b/src/MetaTags/Placement.php
@@ -21,13 +21,10 @@ class Placement extends TagsCollection implements PlacementInterface
      */
     public function toHtml()
     {
-        return $this->map(function ($tag) {
-            if ($tag instanceof Htmlable) {
-                return $tag->toHtml();
-            }
-
-            return (string) $tag;
-        })->implode(PHP_EOL);
+        return $this
+            ->onlyVisible()
+            ->stringifyEntities()
+            ->implode(PHP_EOL);
     }
 
     /**

--- a/src/MetaTags/TagsCollection.php
+++ b/src/MetaTags/TagsCollection.php
@@ -2,16 +2,48 @@
 
 namespace Butschster\Head\MetaTags;
 
+use Butschster\Head\Contracts\MetaTags\Entities\HasVisibilityConditions;
 use Butschster\Head\Contracts\MetaTags\Entities\TagInterface;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Collection;
 
 class TagsCollection extends Collection
 {
     /**
+     * Filter only visible tags
+     * @return TagsCollection
+     */
+    public function onlyVisible()
+    {
+        return $this->filter(function (TagInterface $tag) {
+            if ($tag instanceof HasVisibilityConditions) {
+                return $tag->isVisible();
+            }
+
+            return true;
+        });
+    }
+
+    /**
+     * Convert to string entities
+     * @return TagsCollection
+     */
+    public function stringifyEntities()
+    {
+        return $this->map(function ($tag) {
+            if ($tag instanceof Htmlable) {
+                return $tag->toHtml();
+            }
+
+            return (string)$tag;
+        });
+    }
+
+    /**
      * Set the item at a given offset.
      *
-     * @param  mixed $key
-     * @param  TagInterface $value
+     * @param mixed $key
+     * @param TagInterface $value
      * @return void
      */
     public function offsetSet($key, $value)

--- a/tests/MetaTags/Entities/CommentsTest.php
+++ b/tests/MetaTags/Entities/CommentsTest.php
@@ -41,4 +41,24 @@ COM
             $comment
         );
     }
+
+    function test_by_default_comment_is_visible()
+    {
+        $favicon = new Favicon('http://site.com/favicon.ico');
+        $comment = new Comment($favicon, 'Favicon', 'Close comment');
+
+        $this->assertTrue($comment->isVisible());
+    }
+
+    function test_visibility_condition_can_be_set()
+    {
+        $favicon = new Favicon('http://site.com/favicon.ico');
+        $comment = new Comment($favicon, 'Favicon', 'Close comment');
+
+        // Make it invisible
+        $this->assertFalse($comment->visibleWhen(function () {return false;})->isVisible());
+
+        // Make it visible
+        $this->assertTrue($comment->visibleWhen(function () {return true;})->isVisible());
+    }
 }

--- a/tests/MetaTags/Entities/JavascriptVariablesTest.php
+++ b/tests/MetaTags/Entities/JavascriptVariablesTest.php
@@ -111,6 +111,24 @@ VAR
             , $meta);
 
     }
+
+    function test_by_default_variables_is_visible()
+    {
+        $container = new JavascriptVariables();
+
+        $this->assertTrue($container->isVisible());
+    }
+
+    function test_visibility_condition_can_be_set()
+    {
+        $container = new JavascriptVariables();
+
+        // Make it invisible
+        $this->assertFalse($container->visibleWhen(function () {return false;})->isVisible());
+
+        // Make it visible
+        $this->assertTrue($container->visibleWhen(function () {return true;})->isVisible());
+    }
 }
 
 class NonTransformable {

--- a/tests/MetaTags/Entities/TagTest.php
+++ b/tests/MetaTags/Entities/TagTest.php
@@ -118,4 +118,28 @@ class TagTest extends TestCase
             $tag
         );
     }
+
+    function test_by_default_tag_is_visible()
+    {
+        $tag = Tag::meta([
+            'name' => 'description',
+            'content' => 'Another cool description'
+        ]);
+
+        $this->assertTrue($tag->isVisible());
+    }
+
+    function test_visibility_condition_can_be_set()
+    {
+        $tag = Tag::meta([
+            'name' => 'description',
+            'content' => 'Another cool description'
+        ]);
+
+        // Make it invisible
+        $this->assertFalse($tag->visibleWhen(function () {return false;})->isVisible());
+
+        // Make it visible
+        $this->assertTrue($tag->visibleWhen(function () {return true;})->isVisible());
+    }
 }

--- a/tests/MetaTags/Entities/TitleTest.php
+++ b/tests/MetaTags/Entities/TitleTest.php
@@ -114,4 +114,22 @@ class TitleTest extends TestCase
 
         $this->assertHtmlableContains($text, $title);
     }
+
+    function test_by_default_title_is_visible()
+    {
+        $title = new Title('test');
+
+        $this->assertTrue($title->isVisible());
+    }
+
+    function test_visibility_condition_can_be_set()
+    {
+        $title = new Title('test');
+
+        // Make it invisible
+        $this->assertFalse($title->visibleWhen(function () {return false;})->isVisible());
+
+        // Make it visible
+        $this->assertTrue($title->visibleWhen(function () {return true;})->isVisible());
+    }
 }

--- a/tests/MetaTags/PlacementTest.php
+++ b/tests/MetaTags/PlacementTest.php
@@ -34,4 +34,27 @@ class PlacementTest extends TestCase
         ], $placement);
     }
 
+    function test_invisible_tags_should_be_skipped()
+    {
+        $placement = new Placement();
+
+        $placement->add(Tag::meta([
+            'attr' => 'value'
+        ]));
+
+        $placement->add(Tag::meta([
+            'attr' => 'value1'
+        ])->visibleWhen(function () {
+            return false;
+        }));
+
+        $this->assertHtmlableContains([
+            '<meta attr="value">',
+        ], $placement);
+
+        $this->assertHtmlableNotContains([
+            '<meta attr="value1">',
+        ], $placement);
+    }
+
 }

--- a/tests/Packages/ManagerTest.php
+++ b/tests/Packages/ManagerTest.php
@@ -8,7 +8,7 @@ use Butschster\Tests\TestCase;
 
 class ManagerTest extends TestCase
 {
-    function test_a_pacakge_can_be_registered()
+    function test_a_package_can_be_registered()
     {
         $manager = new Manager();
         $package = new Package('jquery');


### PR DESCRIPTION
issue #11

**Example**

```php
Tag::meta([
    'name' => 'description',
    'content' => 'Another cool description'
])->visibleWhen(function () {
    return Request::ip() === '127.0.0.1';
});
```

