### PR TITLE
Reorder default meta tags attributes

### DIFF
--- a/src/MetaTags/Concerns/InitializeDefaults.php
+++ b/src/MetaTags/Concerns/InitializeDefaults.php
@@ -9,6 +9,14 @@ trait InitializeDefaults
      */
     public function initialize()
     {
+        if (!empty($charset = $this->config('charset'))) {
+            $this->setCharset($charset);
+        }
+
+        if (!empty($viewport = $this->config('viewport'))) {
+            $this->setViewport($viewport);
+        }
+        
         if (!empty($title = $this->config('title.default'))) {
             $this->setTitle($title);
         }
@@ -19,14 +27,6 @@ trait InitializeDefaults
 
         if (!empty($keywords = $this->config('keywords.default'))) {
             $this->setKeywords($keywords);
-        }
-
-        if (!empty($charset = $this->config('charset'))) {
-            $this->setCharset($charset);
-        }
-
-        if (!empty($viewport = $this->config('viewport'))) {
-            $this->setViewport($viewport);
         }
 
         if (!empty($robots = $this->config('robots'))) {


### PR DESCRIPTION
## Problem

Current meta tags default ordering is
- title
- meta description
- keyword
- charset
- viewport

Based on best practice from https://speakerdeck.com/csswizardry/get-your-head-straight?slide=39 charset and viewport should come first then other meta tags

## Solution
change charset + viewport meta tags to first then following others