### PR TITLE
Fixed register service provider for L11

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -33,6 +33,11 @@ class InstallCommand extends Command
     {
         $namespace = Str::replaceLast('\\', '', $this->getLaravel()->getNamespace());
 
+        if (file_exists($this->getLaravel()->bootstrapPath('providers.php'))) {
+            // @phpstan-ignore-next-line
+            return ServiceProvider::addProviderToBootstrapFile("{$namespace}\\Providers\\MetaTagsServiceProvider");
+        }
+
         /** @psalm-suppress UndefinedFunction */
         $config = file_get_contents(config_path('app.php'));
         $line = $namespace . '\Providers\MetaTagsServiceProvider::class';


### PR DESCRIPTION
In base to [https://laravel.com/docs/11.x/upgrade#packages](https://laravel.com/docs/11.x/upgrade#packages)

Registration of services providers is now done in bootstrap/providers.php