### PR TITLE
TypeError thrown if is null

### DIFF
--- a/src/MetaTags/Entities/Tag.php
+++ b/src/MetaTags/Entities/Tag.php
@@ -82,6 +82,8 @@ class Tag implements TagInterface, HasVisibilityConditions, \Stringable
         if (!is_null($value)) {
             return $key . '="' . $value . '"';
         }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
If closure is passed and it returns null, then a TypeError is thrown by the `attributeElement`.  This happens with the CSRF token if the TrustedHosts middleware is used and an untrusted host hits the application.