### PR TITLE
Fix A void function must not return a value error

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Str;
 class InstallCommand extends Command
 {
     protected $signature = 'meta-tags:install';
-    
+
     protected $description = 'Install all of the MetaTags package resources';
 
     public function handle(): void
@@ -35,7 +35,8 @@ class InstallCommand extends Command
 
         if (file_exists($this->getLaravel()->bootstrapPath('providers.php'))) {
             // @phpstan-ignore-next-line
-            return ServiceProvider::addProviderToBootstrapFile("{$namespace}\\Providers\\MetaTagsServiceProvider");
+            ServiceProvider::addProviderToBootstrapFile("{$namespace}\\Providers\\MetaTagsServiceProvider");
+            return;
         }
 
         /** @psalm-suppress UndefinedFunction */


### PR DESCRIPTION
Fixes and issue with updating the package

```
  at vendor/butschster/meta-tags/src/Console/InstallCommand.php:38
     34▕         $namespace = Str::replaceLast('\\', '', $this->getLaravel()->getNamespace());
     35▕
     36▕         if (file_exists($this->getLaravel()->bootstrapPath('providers.php'))) {
     37▕             // @phpstan-ignore-next-line
  ➜  38▕             return ServiceProvider::addProviderToBootstrapFile("{$namespace}\\Providers\\MetaTagsServiceProvider");
     39▕         }
     40▕
     41▕         /** @psalm-suppress UndefinedFunction */
     42▕         $config = file_get_contents(config_path('app.php'));
```