### PR TITLE
Fix Class Butschster\Head\Console\ServiceProvider not found for L11

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -3,6 +3,7 @@
 namespace Butschster\Head\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 
 class InstallCommand extends Command


### PR DESCRIPTION
The line `ServiceProvider::addProviderToBootstrapFile("{$namespace}\\Providers\\MetaTagsServiceProvider"); `tries to find ServiceProvider in the namespace Butschster\Head\Console, which causes an error  `"Class "Butschster\Head\Console\ServiceProvider"` not found
in Laravel 11. Added `use Illuminate\Support\ServiceProvider;` to the file. Fix tested on Laravel 11 and Laravel 10.

