### PR TITLE
fix: make nullable parameter types explicit for PHP 8.1+ compatibility

### DIFF
--- a/src/Contracts/MetaTags/MetaInterface.php
+++ b/src/Contracts/MetaTags/MetaInterface.php
@@ -29,7 +29,7 @@ interface MetaInterface extends Htmlable, PlacementsInterface, Arrayable
      *
      * @param positive-int|null $maxLength
      */
-    public function setTitle(string $title, int $maxLength = null): self;
+    public function setTitle(string $title, ?int $maxLength = null): self;
 
     /**
      * Prepend title part to default title

--- a/src/MetaTags/Concerns/ManageTitle.php
+++ b/src/MetaTags/Concerns/ManageTitle.php
@@ -7,7 +7,7 @@ use Butschster\Head\MetaTags\Entities\Title;
 
 trait ManageTitle
 {
-    public function setTitle(?string $title, int $maxLength = null): self
+    public function setTitle(?string $title, ?int $maxLength = null): self
     {
         $this->getTitle()->setTitle($this->cleanString($title), $maxLength);
 

--- a/src/Packages/Manager.php
+++ b/src/Packages/Manager.php
@@ -23,7 +23,7 @@ class Manager implements ManagerInterface
         return $this;
     }
 
-    public function create(string $name, Closure $callback = null): self
+    public function create(string $name, ?Closure $callback = null): self
     {
         $this->register($package = new Package($name));
 


### PR DESCRIPTION
When running the application on PHP 8.1+, the following deprecation warnings appear:

```
PHP Deprecated:  Butschster\Head\MetaTags\Concerns\ManageTitle::setTitle(): Implicitly marking parameter $maxLength as nullable is deprecated, the explicit nullable type must be used instead
PHP Deprecated:  Butschster\Head\Contracts\MetaTags\MetaInterface::setTitle(): Implicitly marking parameter $maxLength as nullable is deprecated, the explicit nullable type must be used instead
PHP Deprecated:  Butschster\Head\Packages\Manager::create(): Implicitly marking parameter $callback as nullable is deprecated, the explicit nullable type must be used instead
```

These warnings are caused by parameters that are nullable (= null) but not explicitly typed with a nullable type (?type). This PR resolves the warnings by explicitly declaring the types as nullable, ensuring compatibility with PHP 8.1+ while remaining backward-compatible with PHP 8.0.